### PR TITLE
Fixing the getIdentityByUID method to search by uid as opposed to ali…

### DIFF
--- a/src/sdk-client.ts
+++ b/src/sdk-client.ts
@@ -261,7 +261,7 @@ export class SDKClient {
         const api = new IdentitiesBetaApi(this.config)
 
         const requestParameters: IdentitiesBetaApiListIdentitiesRequest = {
-            filters: `alias eq "${uid}"`,
+            filters: `uid eq "${uid}"`,
         }
         const response = await api.listIdentities(requestParameters)
 


### PR DESCRIPTION
…as as alias does not work during the account create